### PR TITLE
Add react-magic-cli --help flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const { listOptions, getOptions } = require('./commands/options')
 
 const [, , ...userArguments] = process.argv
 
+if (userArguments.includes('--help')) reactMagicCliGuide()
+
 if (userArguments.length < 1) exitTerminal('Enter an option argument')
 else if (userArguments.length < 2) exitTerminal('Enter a valid name')
 
@@ -22,5 +24,19 @@ if (options.includes(option)) {
 
 function exitTerminal (message) {
   console.error(chalk.red(message))
+  process.exit()
+}
+
+function reactMagicCliGuide () {
+  const reactMagicCliGuideString = `
+    ✨ React Magic CLI - Guide
+
+    usage: rgc <command> <resource-name>
+
+    Current commands:
+      new            Creates a project based on your answers
+      component      Creates a component in ./src/components
+  `
+  console.info(reactMagicCliGuideString)
   process.exit()
 }


### PR DESCRIPTION
👏 Awesome project, here is a _very_ small contribution that I was able to make the last half-hour reviewing the source code.
How about a git-style `--help` flag so users can ensure they're typing the correct command?

### Preview
![cli-guide](https://user-images.githubusercontent.com/47821093/149706192-5288aa16-3cac-433a-a597-bfca6cf8c008.png)

Happy to see what you think. I'm also reviewing the project cards to see if I can help in other changes.

✌️ Regards!